### PR TITLE
Sync pipeline fixes from upstream vocabularyTemplate PR #3

### DIFF
--- a/.github/actions/github_action_main.py
+++ b/.github/actions/github_action_main.py
@@ -42,7 +42,8 @@ def main():
         sys.exit(-1)
 
     cachepath = "cache/vocabularies.db"
-    sourcevocabdir = "vocabulary"
+    sourcevocabdir = os.environ.get("INPUT_VOCABDIR") or "vocabulary"
+    print(f"github_action_main: source vocab directory: {sourcevocabdir}")
 
     print("github_action_main: target path for output: ", path)
     if path is None:
@@ -69,11 +70,11 @@ def main():
 
         if command == "uijson":
             print("Generating uijson for inclusion in webUI build")
-            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri)
+            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri, cachepath)
         elif command == "docs":
             print("Generating markdown and html docs")
             md_path = os.path.join(path, inputf + ".md")
-            result = _run_docs_in_container(md_path, voc_uri)
+            result = _run_docs_in_container(md_path, voc_uri, cachepath)
             if result == 0:
                 _quarto_render_html(md_path, path)
             else:
@@ -125,9 +126,9 @@ def _run_make_in_container(target: str):
     subprocess.run(["/usr/bin/make", "-C", "/app", "-f", "/app/Makefile", target])
 
 
-def _run_uijson_in_container(output_path: str, vocab_location: str):
+def _run_uijson_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        vocab_args = ["-s", "/app/cache/vocabularies.db", "uijson", vocab_location, "-e"]
+        vocab_args = ["-s", cachepath, "uijson", vocab_location, "-e"]
         testflag = _run_python_in_container("/app/tools/vocab.py", vocab_args, f)
         if testflag == 0:
             print(f"Run_uijson: Successfully wrote uijson file to {output_path}")
@@ -136,9 +137,9 @@ def _run_uijson_in_container(output_path: str, vocab_location: str):
         return 1
 
 
-def _run_docs_in_container(output_path: str, vocab_location: str):
+def _run_docs_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        docs_args = ["/app/cache/vocabularies.db", vocab_location]
+        docs_args = [cachepath, vocab_location]
         testflag = _run_python_in_container("/app/tools/vocab2mdCacheV2.py", docs_args, f)
         if testflag == 0:
             print(f"Docs in container: Successfully wrote doc file {vocab_location} to {output_path}")

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   path: 
     description: 'Path to the output directory for script output'
     required: true
+  vocabdir:
+    description: 'Repository-relative directory containing the source ttl files for this workflow. Defaults to "vocabulary" for single-vocabulary layouts; set to a different directory name to point the action at a per-topic subfolder.'
+    required: false
+    default: 'vocabulary'
   inputttl:
     description: 'list of skos rdf/turtle files **without** the .ttl extension'
     required: true
@@ -37,3 +41,4 @@ runs:   # see https://docs.github.com/en/actions/creating-actions/metadata-synta
     - ${{ inputs.path }}
     - ${{ inputs.inputttl }}
     - ${{ inputs.inputvocaburi }}
+    - ${{ inputs.vocabdir }}

--- a/tools/vocab2mdCacheV2.py
+++ b/tools/vocab2mdCacheV2.py
@@ -132,6 +132,13 @@ def getVocabRoot(g, v):
     Accepts both concept->scheme (``skos:topConceptOf``) and
     scheme->concept (``skos:hasTopConcept``) assertions, since SKOS
     vocabularies in the wild use either (or both).
+
+    If neither assertion appears, falls back to every concept in the
+    scheme treated as a flat root. The fallback honors both direct
+    ``rdf:type skos:Concept`` and subclass typings (``rdf:type ?C`` where
+    ``?C rdfs:subClassOf skos:Concept``) — the latter is needed for
+    vocabularies like MMISW whose items are typed with a bespoke class
+    that declares ``rdfs:subClassOf skos:Concept``.
     """
     q = PFX + """SELECT DISTINCT ?s WHERE {
         { ?s skos:topConceptOf ?vocabulary . }
@@ -139,10 +146,21 @@ def getVocabRoot(g, v):
         { ?vocabulary skos:hasTopConcept ?s . }
     }"""
     qres = g.query(q, initBindings={'vocabulary': v})
-    res = []
-    for row in qres:
-        res.append(row[0])
-    return res
+    res = [row[0] for row in qres]
+    if res:
+        return res
+
+    q = PFX + """SELECT DISTINCT ?s WHERE {
+        ?s skos:inScheme ?vocabulary .
+        {
+            ?s rdf:type skos:Concept .
+        } UNION {
+            ?s rdf:type ?cls .
+            ?cls rdfs:subClassOf skos:Concept .
+        }
+    }"""
+    qres = g.query(q, initBindings={'vocabulary': v})
+    return [row[0] for row in qres]
 
 def getNarrower(g, v, r):
     """Return concepts that are skos:broader of r.


### PR DESCRIPTION
Incremental sync of three items from isamplesorg/vocabularyTemplate#3, the three not already present in this repo:

- **github_action_main.py**: thread `cachepath` through to `_run_docs_in_container` and `_run_uijson_in_container` instead of hardcoding `/app/cache/vocabularies.db` — the load and docs/uijson steps now share one path. Masked here because we commit `cache/` back to `main` each run (build-time COPY puts a stale DB one run behind); fixing it removes the stale-read surprise.
- **vocab2mdCacheV2.getVocabRoot**: new fallback for vocabularies that don't declare top concepts — lists every `skos:inScheme` member as a flat root, honoring both direct `rdf:type skos:Concept` and subclass typings (`?s rdf:type ?cls . ?cls rdfs:subClassOf skos:Concept`). No behavior change for existing vocabularies that do declare top concepts.
- **action.yml**: new optional `vocabdir` input (default `vocabulary`). Existing workflows need no changes.

## Test plan
- [ ] Dispatch `Process vocabularies` on `main` after merge; output should be identical to the last successful run.
